### PR TITLE
Refined regular expressions to handle more scenarios

### DIFF
--- a/Newtonsoft.Json.Serialization.ContractResolverExtentions/SnakeCaseIntegerSeperatedPropertyNamesContractResolver.cs
+++ b/Newtonsoft.Json.Serialization.ContractResolverExtentions/SnakeCaseIntegerSeperatedPropertyNamesContractResolver.cs
@@ -1,12 +1,13 @@
-﻿namespace Newtonsoft.Json.Serialization.ContractResolverExtentions
+﻿using System.Text.RegularExpressions;
+
+namespace Newtonsoft.Json.Serialization.ContractResolverExtentions
 {
     public class SnakeCaseIntegerSeperatedPropertyNamesContractResolver : DefaultContractResolver
     {
-        protected override string ResolvePropertyName(string propertyName)
-        {
-            var startUnderscores = System.Text.RegularExpressions.Regex.Match(propertyName, @"^_+");
-            return startUnderscores + System.Text.RegularExpressions.Regex
-                .Replace(propertyName, @"([A-Z0-9])", "_$1").ToLower().TrimStart('_');
-        }
+      protected internal Regex converter = new Regex(@"((?<=[a-z])(?<b>[A-Z0-9])|(?<=[^_])(?<b>[A-Z][a-z]))");
+      protected override string ResolvePropertyName(string propertyName)
+      {
+        return converter.Replace(propertyName, "_${b}").ToLower();
+      }
     }	
 }

--- a/Newtonsoft.Json.Serialization.ContractResolverExtentions/SnakeCasePropertyNamesContractResolver.cs
+++ b/Newtonsoft.Json.Serialization.ContractResolverExtentions/SnakeCasePropertyNamesContractResolver.cs
@@ -1,12 +1,13 @@
-﻿namespace Newtonsoft.Json.Serialization.ContractResolverExtentions
+﻿using System.Text.RegularExpressions;
+
+namespace Newtonsoft.Json.Serialization.ContractResolverExtentions
 {
     public class SnakeCasePropertyNamesContractResolver : DefaultContractResolver
     {
+        protected internal Regex converter = new Regex(@"((?<=[a-z])(?<b>[A-Z])|(?<=[^_])(?<b>[A-Z][a-z]))");
         protected override string ResolvePropertyName(string propertyName)
         {
-            var startUnderscores = System.Text.RegularExpressions.Regex.Match(propertyName, @"^_+");
-            return startUnderscores + System.Text.RegularExpressions.Regex
-                .Replace(propertyName, @"([A-Z])", "_$1").ToLower().TrimStart('_');
+          return converter.Replace(propertyName, "_${b}").ToLower();
         }
     }
 }


### PR DESCRIPTION
As requested on your blog entry, I've created a pull request. Please do note that I commit my change to SnakeCasePropertyNamesContractResolver even though it does not match the Microsoft naming rules. The reason is two-fold, we can discuss further:

1) DBName is valid per MS since it is a "short" acronym. I would expect it to translate to db_name not d_b_name
2) Where there is a "long" acronym, no behavior is perfect. Say the variable was DBUNAndPW, neither dbun_and_pw is correct nor is d_b_u_n_and_p_w. It is indeterministic, we cannot even assume that every two letters is a short acronym, because it is possible to mix single and double letter combinations, such as ADBICanHandle. My point is, it is more likely that a string of uppercase are a single fragment, and definitely not single letter words (Try mixing :"I" and "A" in a variable name that makes sense in English).
3) It is consistent with the logic of CamelCasePropertyNamesContractResolver. It translates to dbunAndPW (as opposed to previous versions that did dBUNAndPW)
